### PR TITLE
change npm license to MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.12.0",
   "description": "Collection of Safe singleton deployments",
   "homepage": "https://github.com/gnosis/safe-deployments/",
-  "license": "LGPL-3.0",
+  "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
The license was inconsistent on github and npm. This PR aligns them to MIT license

**Question**
Should it be a major version bump?